### PR TITLE
update to latest rpc spec

### DIFF
--- a/src/HS2/HS2.jl
+++ b/src/HS2/HS2.jl
@@ -21,6 +21,7 @@ export TOperationState # enum
 export TOperationType # enum
 export TGetInfoType # enum
 export TFetchOrientation # enum
+export TJobExecutionStatus # enum
 export TTypeEntryPtr # typealias for Int32
 export TIdentifier # typealias for String
 export TPattern # typealias for String
@@ -62,6 +63,8 @@ export TSessionHandle # struct
 export TOperationHandle # struct
 export TOpenSessionReq # struct
 export TOpenSessionResp # struct
+export TSetClientInfoReq # struct
+export TSetClientInfoResp # struct
 export TCloseSessionReq # struct
 export TCloseSessionResp # struct
 export TGetInfoValue # struct
@@ -83,6 +86,10 @@ export TGetColumnsReq # struct
 export TGetColumnsResp # struct
 export TGetFunctionsReq # struct
 export TGetFunctionsResp # struct
+export TGetPrimaryKeysReq # struct
+export TGetPrimaryKeysResp # struct
+export TGetCrossReferenceReq # struct
+export TGetCrossReferenceResp # struct
 export TGetOperationStatusReq # struct
 export TGetOperationStatusResp # struct
 export TCancelOperationReq # struct
@@ -99,6 +106,9 @@ export TCancelDelegationTokenReq # struct
 export TCancelDelegationTokenResp # struct
 export TRenewDelegationTokenReq # struct
 export TRenewDelegationTokenResp # struct
+export TProgressUpdateResp # struct
+export TGetQueryIdReq # struct
+export TGetQueryIdResp # struct
 export PRIMITIVE_TYPES # const
 export COMPLEX_TYPES # const
 export COLLECTION_TYPES # const
@@ -106,7 +116,7 @@ export TYPE_NAMES # const
 export CHARACTER_MAXIMUM_LENGTH # const
 export PRECISION # const
 export SCALE # const
-export TCLIServiceProcessor, TCLIServiceClient, TCLIServiceClientBase, OpenSession, CloseSession, GetInfo, ExecuteStatement, GetTypeInfo, GetCatalogs, GetSchemas, GetTables, GetTableTypes, GetColumns, GetFunctions, GetOperationStatus, CancelOperation, CloseOperation, GetResultSetMetadata, FetchResults, GetDelegationToken, CancelDelegationToken, RenewDelegationToken # service TCLIService
+export TCLIServiceProcessor, TCLIServiceClient, TCLIServiceClientBase, OpenSession, CloseSession, GetInfo, ExecuteStatement, GetTypeInfo, GetCatalogs, GetSchemas, GetTables, GetTableTypes, GetColumns, GetFunctions, GetPrimaryKeys, GetCrossReference, GetOperationStatus, CancelOperation, CloseOperation, GetResultSetMetadata, FetchResults, GetDelegationToken, CancelDelegationToken, RenewDelegationToken, GetQueryId, SetClientInfo # service TCLIService
 
 include("HS2_constants.jl")
 include("HS2_types.jl")

--- a/src/HS2/HS2_constants.jl
+++ b/src/HS2/HS2_constants.jl
@@ -3,7 +3,7 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 
-const PRIMITIVE_TYPES = union!(Set{Int32}(), Int32[  Int32(0),   Int32(1),   Int32(2),   Int32(3),   Int32(4),   Int32(5),   Int32(6),   Int32(7),   Int32(8),   Int32(9),   Int32(15),   Int32(16),   Int32(17),   Int32(18),   Int32(19),   Int32(20),   Int32(21)
+const PRIMITIVE_TYPES = union!(Set{Int32}(), Int32[  Int32(0),   Int32(1),   Int32(2),   Int32(3),   Int32(4),   Int32(5),   Int32(6),   Int32(7),   Int32(8),   Int32(9),   Int32(15),   Int32(16),   Int32(17),   Int32(18),   Int32(19),   Int32(20),   Int32(21),   Int32(22)
 ])
 const COMPLEX_TYPES = union!(Set{Int32}(), Int32[  Int32(10),   Int32(11),   Int32(12),   Int32(13),   Int32(14)
 ])
@@ -30,7 +30,8 @@ const TYPE_NAMES = Dict(
   Int32(18) => "VARCHAR",
   Int32(19) => "CHAR",
   Int32(20) => "INTERVAL_YEAR_MONTH",
-  Int32(21) => "INTERVAL_DAY_TIME"
+  Int32(21) => "INTERVAL_DAY_TIME",
+  Int32(22) => "TIMESTAMP WITH LOCAL TIME ZONE"
 )
 const CHARACTER_MAXIMUM_LENGTH = "characterMaximumLength"
 const PRECISION = "precision"

--- a/src/HS2/HS2_types.jl
+++ b/src/HS2/HS2_types.jl
@@ -12,8 +12,11 @@ struct _enum_TProtocolVersion
   HIVE_CLI_SERVICE_PROTOCOL_V6::Int32
   HIVE_CLI_SERVICE_PROTOCOL_V7::Int32
   HIVE_CLI_SERVICE_PROTOCOL_V8::Int32
+  HIVE_CLI_SERVICE_PROTOCOL_V9::Int32
+  HIVE_CLI_SERVICE_PROTOCOL_V10::Int32
+  HIVE_CLI_SERVICE_PROTOCOL_V11::Int32
 end
-const TProtocolVersion = _enum_TProtocolVersion(Int32(0), Int32(1), Int32(2), Int32(3), Int32(4), Int32(5), Int32(6), Int32(7))
+const TProtocolVersion = _enum_TProtocolVersion(Int32(0), Int32(1), Int32(2), Int32(3), Int32(4), Int32(5), Int32(6), Int32(7), Int32(8), Int32(9), Int32(10))
 
 struct _enum_TTypeId
   BOOLEAN_TYPE::Int32
@@ -38,8 +41,9 @@ struct _enum_TTypeId
   CHAR_TYPE::Int32
   INTERVAL_YEAR_MONTH_TYPE::Int32
   INTERVAL_DAY_TIME_TYPE::Int32
+  TIMESTAMPLOCALTZ_TYPE::Int32
 end
-const TTypeId = _enum_TTypeId(Int32(0), Int32(1), Int32(2), Int32(3), Int32(4), Int32(5), Int32(6), Int32(7), Int32(8), Int32(9), Int32(10), Int32(11), Int32(12), Int32(13), Int32(14), Int32(15), Int32(16), Int32(17), Int32(18), Int32(19), Int32(20), Int32(21))
+const TTypeId = _enum_TTypeId(Int32(0), Int32(1), Int32(2), Int32(3), Int32(4), Int32(5), Int32(6), Int32(7), Int32(8), Int32(9), Int32(10), Int32(11), Int32(12), Int32(13), Int32(14), Int32(15), Int32(16), Int32(17), Int32(18), Int32(19), Int32(20), Int32(21), Int32(22))
 
 struct _enum_TStatusCode
   SUCCESS_STATUS::Int32
@@ -59,8 +63,9 @@ struct _enum_TOperationState
   ERROR_STATE::Int32
   UKNOWN_STATE::Int32
   PENDING_STATE::Int32
+  TIMEDOUT_STATE::Int32
 end
-const TOperationState = _enum_TOperationState(Int32(0), Int32(1), Int32(2), Int32(3), Int32(4), Int32(5), Int32(6), Int32(7))
+const TOperationState = _enum_TOperationState(Int32(0), Int32(1), Int32(2), Int32(3), Int32(4), Int32(5), Int32(6), Int32(7), Int32(8))
 
 struct _enum_TOperationType
   EXECUTE_STATEMENT::Int32
@@ -123,8 +128,9 @@ struct _enum_TGetInfoType
   CLI_CATALOG_NAME::Int32
   CLI_COLLATION_SEQ::Int32
   CLI_MAX_IDENTIFIER_LEN::Int32
+  CLI_ODBC_KEYWORDS::Int32
 end
-const TGetInfoType = _enum_TGetInfoType(Int32(0), Int32(1), Int32(2), Int32(8), Int32(13), Int32(14), Int32(17), Int32(18), Int32(19), Int32(20), Int32(23), Int32(25), Int32(26), Int32(28), Int32(29), Int32(30), Int32(31), Int32(32), Int32(34), Int32(35), Int32(43), Int32(46), Int32(47), Int32(72), Int32(73), Int32(81), Int32(85), Int32(86), Int32(90), Int32(94), Int32(97), Int32(98), Int32(99), Int32(100), Int32(101), Int32(102), Int32(104), Int32(105), Int32(106), Int32(107), Int32(115), Int32(10000), Int32(10001), Int32(10002), Int32(10003), Int32(10004), Int32(10005))
+const TGetInfoType = _enum_TGetInfoType(Int32(0), Int32(1), Int32(2), Int32(8), Int32(13), Int32(14), Int32(17), Int32(18), Int32(19), Int32(20), Int32(23), Int32(25), Int32(26), Int32(28), Int32(29), Int32(30), Int32(31), Int32(32), Int32(34), Int32(35), Int32(43), Int32(46), Int32(47), Int32(72), Int32(73), Int32(81), Int32(85), Int32(86), Int32(90), Int32(94), Int32(97), Int32(98), Int32(99), Int32(100), Int32(101), Int32(102), Int32(104), Int32(105), Int32(106), Int32(107), Int32(115), Int32(10000), Int32(10001), Int32(10002), Int32(10003), Int32(10004), Int32(10005), Int32(10006))
 
 struct _enum_TFetchOrientation
   FETCH_NEXT::Int32
@@ -135,6 +141,13 @@ struct _enum_TFetchOrientation
   FETCH_LAST::Int32
 end
 const TFetchOrientation = _enum_TFetchOrientation(Int32(0), Int32(1), Int32(2), Int32(3), Int32(4), Int32(5))
+
+struct _enum_TJobExecutionStatus
+  IN_PROGRESS::Int32
+  COMPLETE::Int32
+  NOT_AVAILABLE::Int32
+end
+const TJobExecutionStatus = _enum_TJobExecutionStatus(Int32(0), Int32(1), Int32(2))
 
 const TTypeEntryPtr = Int32
 
@@ -344,9 +357,11 @@ mutable struct TRowSet <: Thrift.TMsg
   startRowOffset::Int64
   rows::Vector{TRow}
   columns::Vector{TColumn}
+  binaryColumns::Vector{UInt8}
+  columnCount::Int32
   TRowSet() = (o=new(); fillunset(o); o)
 end # mutable struct TRowSet
-meta(t::Type{TRowSet}) = meta(t, Symbol[:columns], Int[], Dict{Symbol,Any}())
+meta(t::Type{TRowSet}) = meta(t, Symbol[:columns,:binaryColumns,:columnCount], Int[], Dict{Symbol,Any}())
 
 mutable struct TStatus <: Thrift.TMsg
   statusCode::Int32
@@ -385,7 +400,7 @@ mutable struct TOpenSessionReq <: Thrift.TMsg
   configuration::Dict{String,String}
   TOpenSessionReq() = (o=new(); fillunset(o); o)
 end # mutable struct TOpenSessionReq
-meta(t::Type{TOpenSessionReq}) = meta(t, Symbol[:username,:password,:configuration], Int[], Dict{Symbol,Any}(:client_protocol => Int32(7)))
+meta(t::Type{TOpenSessionReq}) = meta(t, Symbol[:username,:password,:configuration], Int[], Dict{Symbol,Any}(:client_protocol => Int32(9)))
 
 mutable struct TOpenSessionResp <: Thrift.TMsg
   status::TStatus
@@ -394,7 +409,19 @@ mutable struct TOpenSessionResp <: Thrift.TMsg
   configuration::Dict{String,String}
   TOpenSessionResp() = (o=new(); fillunset(o); o)
 end # mutable struct TOpenSessionResp
-meta(t::Type{TOpenSessionResp}) = meta(t, Symbol[:sessionHandle,:configuration], Int[], Dict{Symbol,Any}(:serverProtocolVersion => Int32(7)))
+meta(t::Type{TOpenSessionResp}) = meta(t, Symbol[:sessionHandle,:configuration], Int[], Dict{Symbol,Any}(:serverProtocolVersion => Int32(9)))
+
+mutable struct TSetClientInfoReq <: Thrift.TMsg
+  sessionHandle::TSessionHandle
+  configuration::Dict{String,String}
+  TSetClientInfoReq() = (o=new(); fillunset(o); o)
+end # mutable struct TSetClientInfoReq
+meta(t::Type{TSetClientInfoReq}) = meta(t, Symbol[:configuration], Int[], Dict{Symbol,Any}())
+
+mutable struct TSetClientInfoResp <: Thrift.TMsg
+  status::TStatus
+  TSetClientInfoResp() = (o=new(); fillunset(o); o)
+end # mutable struct TSetClientInfoResp
 
 mutable struct TCloseSessionReq <: Thrift.TMsg
   sessionHandle::TSessionHandle
@@ -434,9 +461,10 @@ mutable struct TExecuteStatementReq <: Thrift.TMsg
   statement::String
   confOverlay::Dict{String,String}
   runAsync::Bool
+  queryTimeout::Int64
   TExecuteStatementReq() = (o=new(); fillunset(o); o)
 end # mutable struct TExecuteStatementReq
-meta(t::Type{TExecuteStatementReq}) = meta(t, Symbol[:confOverlay,:runAsync], Int[], Dict{Symbol,Any}(:runAsync => false))
+meta(t::Type{TExecuteStatementReq}) = meta(t, Symbol[:confOverlay,:runAsync,:queryTimeout], Int[], Dict{Symbol,Any}(:runAsync => false, :queryTimeout => Int64(0)))
 
 mutable struct TExecuteStatementResp <: Thrift.TMsg
   status::TStatus
@@ -546,10 +574,57 @@ mutable struct TGetFunctionsResp <: Thrift.TMsg
 end # mutable struct TGetFunctionsResp
 meta(t::Type{TGetFunctionsResp}) = meta(t, Symbol[:operationHandle], Int[], Dict{Symbol,Any}())
 
+mutable struct TGetPrimaryKeysReq <: Thrift.TMsg
+  sessionHandle::TSessionHandle
+  catalogName::TIdentifier
+  schemaName::TIdentifier
+  tableName::TIdentifier
+  TGetPrimaryKeysReq() = (o=new(); fillunset(o); o)
+end # mutable struct TGetPrimaryKeysReq
+meta(t::Type{TGetPrimaryKeysReq}) = meta(t, Symbol[:catalogName,:schemaName,:tableName], Int[], Dict{Symbol,Any}())
+
+mutable struct TGetPrimaryKeysResp <: Thrift.TMsg
+  status::TStatus
+  operationHandle::TOperationHandle
+  TGetPrimaryKeysResp() = (o=new(); fillunset(o); o)
+end # mutable struct TGetPrimaryKeysResp
+meta(t::Type{TGetPrimaryKeysResp}) = meta(t, Symbol[:operationHandle], Int[], Dict{Symbol,Any}())
+
+mutable struct TGetCrossReferenceReq <: Thrift.TMsg
+  sessionHandle::TSessionHandle
+  parentCatalogName::TIdentifier
+  parentSchemaName::TIdentifier
+  parentTableName::TIdentifier
+  foreignCatalogName::TIdentifier
+  foreignSchemaName::TIdentifier
+  foreignTableName::TIdentifier
+  TGetCrossReferenceReq() = (o=new(); fillunset(o); o)
+end # mutable struct TGetCrossReferenceReq
+meta(t::Type{TGetCrossReferenceReq}) = meta(t, Symbol[:parentCatalogName,:parentSchemaName,:parentTableName,:foreignCatalogName,:foreignSchemaName,:foreignTableName], Int[], Dict{Symbol,Any}())
+
+mutable struct TGetCrossReferenceResp <: Thrift.TMsg
+  status::TStatus
+  operationHandle::TOperationHandle
+  TGetCrossReferenceResp() = (o=new(); fillunset(o); o)
+end # mutable struct TGetCrossReferenceResp
+meta(t::Type{TGetCrossReferenceResp}) = meta(t, Symbol[:operationHandle], Int[], Dict{Symbol,Any}())
+
 mutable struct TGetOperationStatusReq <: Thrift.TMsg
   operationHandle::TOperationHandle
+  getProgressUpdate::Bool
   TGetOperationStatusReq() = (o=new(); fillunset(o); o)
 end # mutable struct TGetOperationStatusReq
+meta(t::Type{TGetOperationStatusReq}) = meta(t, Symbol[:getProgressUpdate], Int[], Dict{Symbol,Any}())
+
+mutable struct TProgressUpdateResp <: Thrift.TMsg
+  headerNames::Vector{String}
+  rows::Vector{Vector{String}}
+  progressedPercentage::Float64
+  status::Int32
+  footerSummary::String
+  startTime::Int64
+  TProgressUpdateResp() = (o=new(); fillunset(o); o)
+end # mutable struct TProgressUpdateResp
 
 mutable struct TGetOperationStatusResp <: Thrift.TMsg
   status::TStatus
@@ -557,9 +632,14 @@ mutable struct TGetOperationStatusResp <: Thrift.TMsg
   sqlState::String
   errorCode::Int32
   errorMessage::String
+  taskStatus::String
+  operationStarted::Int64
+  operationCompleted::Int64
+  hasResultSet::Bool
+  progressUpdateResponse::TProgressUpdateResp
   TGetOperationStatusResp() = (o=new(); fillunset(o); o)
 end # mutable struct TGetOperationStatusResp
-meta(t::Type{TGetOperationStatusResp}) = meta(t, Symbol[:operationState,:sqlState,:errorCode,:errorMessage], Int[], Dict{Symbol,Any}())
+meta(t::Type{TGetOperationStatusResp}) = meta(t, Symbol[:operationState,:sqlState,:errorCode,:errorMessage,:taskStatus,:operationStarted,:operationCompleted,:hasResultSet,:progressUpdateResponse], Int[], Dict{Symbol,Any}())
 
 mutable struct TCancelOperationReq <: Thrift.TMsg
   operationHandle::TOperationHandle
@@ -645,5 +725,15 @@ mutable struct TRenewDelegationTokenResp <: Thrift.TMsg
   status::TStatus
   TRenewDelegationTokenResp() = (o=new(); fillunset(o); o)
 end # mutable struct TRenewDelegationTokenResp
+
+mutable struct TGetQueryIdReq <: Thrift.TMsg
+  operationHandle::TOperationHandle
+  TGetQueryIdReq() = (o=new(); fillunset(o); o)
+end # mutable struct TGetQueryIdReq
+
+mutable struct TGetQueryIdResp <: Thrift.TMsg
+  queryId::String
+  TGetQueryIdResp() = (o=new(); fillunset(o); o)
+end # mutable struct TGetQueryIdResp
 
 abstract type TCLIServiceClientBase end

--- a/src/HS2/TCLIService.jl
+++ b/src/HS2/TCLIService.jl
@@ -159,6 +159,34 @@ mutable struct GetFunctions_result
 end # mutable struct GetFunctions_result
 meta(t::Type{GetFunctions_result}) = meta(t, Symbol[:success], Int[0], Dict{Symbol,Any}())
 
+# types encapsulating arguments and return values of method GetPrimaryKeys
+
+mutable struct GetPrimaryKeys_args <: Thrift.TMsg
+  req::TGetPrimaryKeysReq
+  GetPrimaryKeys_args() = (o=new(); fillunset(o); o)
+end # mutable struct GetPrimaryKeys_args
+
+mutable struct GetPrimaryKeys_result
+  success::TGetPrimaryKeysResp
+  GetPrimaryKeys_result() = (o=new(); fillunset(o); o)
+  GetPrimaryKeys_result(success) = (o=new(); fillset(o, :success); o.success=success; o)
+end # mutable struct GetPrimaryKeys_result
+meta(t::Type{GetPrimaryKeys_result}) = meta(t, Symbol[:success], Int[0], Dict{Symbol,Any}())
+
+# types encapsulating arguments and return values of method GetCrossReference
+
+mutable struct GetCrossReference_args <: Thrift.TMsg
+  req::TGetCrossReferenceReq
+  GetCrossReference_args() = (o=new(); fillunset(o); o)
+end # mutable struct GetCrossReference_args
+
+mutable struct GetCrossReference_result
+  success::TGetCrossReferenceResp
+  GetCrossReference_result() = (o=new(); fillunset(o); o)
+  GetCrossReference_result(success) = (o=new(); fillset(o, :success); o.success=success; o)
+end # mutable struct GetCrossReference_result
+meta(t::Type{GetCrossReference_result}) = meta(t, Symbol[:success], Int[0], Dict{Symbol,Any}())
+
 # types encapsulating arguments and return values of method GetOperationStatus
 
 mutable struct GetOperationStatus_args <: Thrift.TMsg
@@ -271,6 +299,34 @@ mutable struct RenewDelegationToken_result
 end # mutable struct RenewDelegationToken_result
 meta(t::Type{RenewDelegationToken_result}) = meta(t, Symbol[:success], Int[0], Dict{Symbol,Any}())
 
+# types encapsulating arguments and return values of method GetQueryId
+
+mutable struct GetQueryId_args <: Thrift.TMsg
+  req::TGetQueryIdReq
+  GetQueryId_args() = (o=new(); fillunset(o); o)
+end # mutable struct GetQueryId_args
+
+mutable struct GetQueryId_result
+  success::TGetQueryIdResp
+  GetQueryId_result() = (o=new(); fillunset(o); o)
+  GetQueryId_result(success) = (o=new(); fillset(o, :success); o.success=success; o)
+end # mutable struct GetQueryId_result
+meta(t::Type{GetQueryId_result}) = meta(t, Symbol[:success], Int[0], Dict{Symbol,Any}())
+
+# types encapsulating arguments and return values of method SetClientInfo
+
+mutable struct SetClientInfo_args <: Thrift.TMsg
+  req::TSetClientInfoReq
+  SetClientInfo_args() = (o=new(); fillunset(o); o)
+end # mutable struct SetClientInfo_args
+
+mutable struct SetClientInfo_result
+  success::TSetClientInfoResp
+  SetClientInfo_result() = (o=new(); fillunset(o); o)
+  SetClientInfo_result(success) = (o=new(); fillset(o, :success); o.success=success; o)
+end # mutable struct SetClientInfo_result
+meta(t::Type{SetClientInfo_result}) = meta(t, Symbol[:success], Int[0], Dict{Symbol,Any}())
+
 
 
 # Processor for TCLIService service (to be used in server implementation)
@@ -289,6 +345,8 @@ mutable struct TCLIServiceProcessor <: TProcessor
     handle(p.tp, ThriftHandler("GetTableTypes", _GetTableTypes, GetTableTypes_args, GetTableTypes_result))
     handle(p.tp, ThriftHandler("GetColumns", _GetColumns, GetColumns_args, GetColumns_result))
     handle(p.tp, ThriftHandler("GetFunctions", _GetFunctions, GetFunctions_args, GetFunctions_result))
+    handle(p.tp, ThriftHandler("GetPrimaryKeys", _GetPrimaryKeys, GetPrimaryKeys_args, GetPrimaryKeys_result))
+    handle(p.tp, ThriftHandler("GetCrossReference", _GetCrossReference, GetCrossReference_args, GetCrossReference_result))
     handle(p.tp, ThriftHandler("GetOperationStatus", _GetOperationStatus, GetOperationStatus_args, GetOperationStatus_result))
     handle(p.tp, ThriftHandler("CancelOperation", _CancelOperation, CancelOperation_args, CancelOperation_result))
     handle(p.tp, ThriftHandler("CloseOperation", _CloseOperation, CloseOperation_args, CloseOperation_result))
@@ -297,6 +355,8 @@ mutable struct TCLIServiceProcessor <: TProcessor
     handle(p.tp, ThriftHandler("GetDelegationToken", _GetDelegationToken, GetDelegationToken_args, GetDelegationToken_result))
     handle(p.tp, ThriftHandler("CancelDelegationToken", _CancelDelegationToken, CancelDelegationToken_args, CancelDelegationToken_result))
     handle(p.tp, ThriftHandler("RenewDelegationToken", _RenewDelegationToken, RenewDelegationToken_args, RenewDelegationToken_result))
+    handle(p.tp, ThriftHandler("GetQueryId", _GetQueryId, GetQueryId_args, GetQueryId_result))
+    handle(p.tp, ThriftHandler("SetClientInfo", _SetClientInfo, SetClientInfo_args, SetClientInfo_result))
     p
   end
   _OpenSession(inp::OpenSession_args) = OpenSession_result(OpenSession(inp.req))
@@ -310,6 +370,8 @@ mutable struct TCLIServiceProcessor <: TProcessor
   _GetTableTypes(inp::GetTableTypes_args) = GetTableTypes_result(GetTableTypes(inp.req))
   _GetColumns(inp::GetColumns_args) = GetColumns_result(GetColumns(inp.req))
   _GetFunctions(inp::GetFunctions_args) = GetFunctions_result(GetFunctions(inp.req))
+  _GetPrimaryKeys(inp::GetPrimaryKeys_args) = GetPrimaryKeys_result(GetPrimaryKeys(inp.req))
+  _GetCrossReference(inp::GetCrossReference_args) = GetCrossReference_result(GetCrossReference(inp.req))
   _GetOperationStatus(inp::GetOperationStatus_args) = GetOperationStatus_result(GetOperationStatus(inp.req))
   _CancelOperation(inp::CancelOperation_args) = CancelOperation_result(CancelOperation(inp.req))
   _CloseOperation(inp::CloseOperation_args) = CloseOperation_result(CloseOperation(inp.req))
@@ -318,6 +380,8 @@ mutable struct TCLIServiceProcessor <: TProcessor
   _GetDelegationToken(inp::GetDelegationToken_args) = GetDelegationToken_result(GetDelegationToken(inp.req))
   _CancelDelegationToken(inp::CancelDelegationToken_args) = CancelDelegationToken_result(CancelDelegationToken(inp.req))
   _RenewDelegationToken(inp::RenewDelegationToken_args) = RenewDelegationToken_result(RenewDelegationToken(inp.req))
+  _GetQueryId(inp::GetQueryId_args) = GetQueryId_result(GetQueryId(inp.req))
+  _SetClientInfo(inp::SetClientInfo_args) = SetClientInfo_result(SetClientInfo(inp.req))
 end # mutable struct TCLIServiceProcessor
 process(p::TCLIServiceProcessor, inp::TProtocol, outp::TProtocol) = process(p.tp, inp, outp)
 distribute(p::TCLIServiceProcessor) = distribute(p.tp)
@@ -346,6 +410,10 @@ distribute(p::TCLIServiceProcessor) = distribute(p.tp)
 #     # returns TGetColumnsResp
 # function GetFunctions(req::TGetFunctionsReq)
 #     # returns TGetFunctionsResp
+# function GetPrimaryKeys(req::TGetPrimaryKeysReq)
+#     # returns TGetPrimaryKeysResp
+# function GetCrossReference(req::TGetCrossReferenceReq)
+#     # returns TGetCrossReferenceResp
 # function GetOperationStatus(req::TGetOperationStatusReq)
 #     # returns TGetOperationStatusResp
 # function CancelOperation(req::TCancelOperationReq)
@@ -362,6 +430,10 @@ distribute(p::TCLIServiceProcessor) = distribute(p.tp)
 #     # returns TCancelDelegationTokenResp
 # function RenewDelegationToken(req::TRenewDelegationTokenReq)
 #     # returns TRenewDelegationTokenResp
+# function GetQueryId(req::TGetQueryIdReq)
+#     # returns TGetQueryIdResp
+# function SetClientInfo(req::TSetClientInfoReq)
+#     # returns TSetClientInfoResp
 
 
 # Client implementation for TCLIService service
@@ -591,6 +663,46 @@ function GetFunctions(c::TCLIServiceClientBase, req::TGetFunctionsReq)
   throw(Thrift.TApplicationException(Thrift.ApplicationExceptionType.MISSING_RESULT, "retrieve failed: unknown result"))
 end # function GetFunctions
 
+# Client callable method for GetPrimaryKeys
+function GetPrimaryKeys(c::TCLIServiceClientBase, req::TGetPrimaryKeysReq)
+  p = c.p
+  c.seqid = (c.seqid < (2^31-1)) ? (c.seqid+1) : 0
+  Thrift.writeMessageBegin(p, "GetPrimaryKeys", Thrift.MessageType.CALL, c.seqid)
+  inp = GetPrimaryKeys_args()
+  Thrift.set_field!(inp, :req, req)
+  Thrift.write(p, inp)
+  Thrift.writeMessageEnd(p)
+  Thrift.flush(p.t)
+  
+  (fname, mtype, rseqid) = Thrift.readMessageBegin(p)
+  (mtype == Thrift.MessageType.EXCEPTION) && throw(Thrift.read(p, Thrift.TApplicationException()))
+  outp = Thrift.read(p, GetPrimaryKeys_result())
+  Thrift.readMessageEnd(p)
+  (rseqid != c.seqid) && throw(Thrift.TApplicationException(ApplicationExceptionType.BAD_SEQUENCE_ID, "response sequence id $rseqid did not match request ($(c.seqid))"))
+  Thrift.has_field(outp, :success) && (return Thrift.get_field(outp, :success))
+  throw(Thrift.TApplicationException(Thrift.ApplicationExceptionType.MISSING_RESULT, "retrieve failed: unknown result"))
+end # function GetPrimaryKeys
+
+# Client callable method for GetCrossReference
+function GetCrossReference(c::TCLIServiceClientBase, req::TGetCrossReferenceReq)
+  p = c.p
+  c.seqid = (c.seqid < (2^31-1)) ? (c.seqid+1) : 0
+  Thrift.writeMessageBegin(p, "GetCrossReference", Thrift.MessageType.CALL, c.seqid)
+  inp = GetCrossReference_args()
+  Thrift.set_field!(inp, :req, req)
+  Thrift.write(p, inp)
+  Thrift.writeMessageEnd(p)
+  Thrift.flush(p.t)
+  
+  (fname, mtype, rseqid) = Thrift.readMessageBegin(p)
+  (mtype == Thrift.MessageType.EXCEPTION) && throw(Thrift.read(p, Thrift.TApplicationException()))
+  outp = Thrift.read(p, GetCrossReference_result())
+  Thrift.readMessageEnd(p)
+  (rseqid != c.seqid) && throw(Thrift.TApplicationException(ApplicationExceptionType.BAD_SEQUENCE_ID, "response sequence id $rseqid did not match request ($(c.seqid))"))
+  Thrift.has_field(outp, :success) && (return Thrift.get_field(outp, :success))
+  throw(Thrift.TApplicationException(Thrift.ApplicationExceptionType.MISSING_RESULT, "retrieve failed: unknown result"))
+end # function GetCrossReference
+
 # Client callable method for GetOperationStatus
 function GetOperationStatus(c::TCLIServiceClientBase, req::TGetOperationStatusReq)
   p = c.p
@@ -750,4 +862,44 @@ function RenewDelegationToken(c::TCLIServiceClientBase, req::TRenewDelegationTok
   Thrift.has_field(outp, :success) && (return Thrift.get_field(outp, :success))
   throw(Thrift.TApplicationException(Thrift.ApplicationExceptionType.MISSING_RESULT, "retrieve failed: unknown result"))
 end # function RenewDelegationToken
+
+# Client callable method for GetQueryId
+function GetQueryId(c::TCLIServiceClientBase, req::TGetQueryIdReq)
+  p = c.p
+  c.seqid = (c.seqid < (2^31-1)) ? (c.seqid+1) : 0
+  Thrift.writeMessageBegin(p, "GetQueryId", Thrift.MessageType.CALL, c.seqid)
+  inp = GetQueryId_args()
+  Thrift.set_field!(inp, :req, req)
+  Thrift.write(p, inp)
+  Thrift.writeMessageEnd(p)
+  Thrift.flush(p.t)
+  
+  (fname, mtype, rseqid) = Thrift.readMessageBegin(p)
+  (mtype == Thrift.MessageType.EXCEPTION) && throw(Thrift.read(p, Thrift.TApplicationException()))
+  outp = Thrift.read(p, GetQueryId_result())
+  Thrift.readMessageEnd(p)
+  (rseqid != c.seqid) && throw(Thrift.TApplicationException(ApplicationExceptionType.BAD_SEQUENCE_ID, "response sequence id $rseqid did not match request ($(c.seqid))"))
+  Thrift.has_field(outp, :success) && (return Thrift.get_field(outp, :success))
+  throw(Thrift.TApplicationException(Thrift.ApplicationExceptionType.MISSING_RESULT, "retrieve failed: unknown result"))
+end # function GetQueryId
+
+# Client callable method for SetClientInfo
+function SetClientInfo(c::TCLIServiceClientBase, req::TSetClientInfoReq)
+  p = c.p
+  c.seqid = (c.seqid < (2^31-1)) ? (c.seqid+1) : 0
+  Thrift.writeMessageBegin(p, "SetClientInfo", Thrift.MessageType.CALL, c.seqid)
+  inp = SetClientInfo_args()
+  Thrift.set_field!(inp, :req, req)
+  Thrift.write(p, inp)
+  Thrift.writeMessageEnd(p)
+  Thrift.flush(p.t)
+  
+  (fname, mtype, rseqid) = Thrift.readMessageBegin(p)
+  (mtype == Thrift.MessageType.EXCEPTION) && throw(Thrift.read(p, Thrift.TApplicationException()))
+  outp = Thrift.read(p, SetClientInfo_result())
+  Thrift.readMessageEnd(p)
+  (rseqid != c.seqid) && throw(Thrift.TApplicationException(ApplicationExceptionType.BAD_SEQUENCE_ID, "response sequence id $rseqid did not match request ($(c.seqid))"))
+  Thrift.has_field(outp, :success) && (return Thrift.get_field(outp, :success))
+  throw(Thrift.TApplicationException(Thrift.ApplicationExceptionType.MISSING_RESULT, "retrieve failed: unknown result"))
+end # function SetClientInfo
 

--- a/thrift/HS2.thrift
+++ b/thrift/HS2.thrift
@@ -32,14 +32,14 @@
 // * Service names begin with the letter "T", use a capital letter for each
 //   new word (with no underscores), and end with the word "Service".
 
-namespace java org.apache.hive.service.cli.thrift
-namespace cpp apache.hive.service.cli.thrift
+namespace java org.apache.hive.service.rpc.thrift
+namespace cpp apache.hive.service.rpc.thrift
 
 // List of protocol versions. A new token should be
 // added to the end of this list every time a change is made.
 enum TProtocolVersion {
   HIVE_CLI_SERVICE_PROTOCOL_V1,
-  
+
   // V2 adds support for asynchronous execution
   HIVE_CLI_SERVICE_PROTOCOL_V2
 
@@ -60,6 +60,15 @@ enum TProtocolVersion {
 
   // V8 adds support for interval types
   HIVE_CLI_SERVICE_PROTOCOL_V8
+
+  // V9 adds support for serializing ResultSets in SerDe
+  HIVE_CLI_SERVICE_PROTOCOL_V9
+
+  // V10 adds support for in place updates via GetOperationStatus
+  HIVE_CLI_SERVICE_PROTOCOL_V10
+
+  // V11 adds timestamp with local time zone type
+  HIVE_CLI_SERVICE_PROTOCOL_V11
 }
 
 enum TTypeId {
@@ -84,9 +93,10 @@ enum TTypeId {
   VARCHAR_TYPE,
   CHAR_TYPE,
   INTERVAL_YEAR_MONTH_TYPE,
-  INTERVAL_DAY_TIME_TYPE
+  INTERVAL_DAY_TIME_TYPE,
+  TIMESTAMPLOCALTZ_TYPE
 }
-  
+
 const set<TTypeId> PRIMITIVE_TYPES = [
   TTypeId.BOOLEAN_TYPE,
   TTypeId.TINYINT_TYPE,
@@ -104,7 +114,8 @@ const set<TTypeId> PRIMITIVE_TYPES = [
   TTypeId.VARCHAR_TYPE,
   TTypeId.CHAR_TYPE,
   TTypeId.INTERVAL_YEAR_MONTH_TYPE,
-  TTypeId.INTERVAL_DAY_TIME_TYPE
+  TTypeId.INTERVAL_DAY_TIME_TYPE,
+  TTypeId.TIMESTAMPLOCALTZ_TYPE
 ]
 
 const set<TTypeId> COMPLEX_TYPES = [
@@ -142,6 +153,7 @@ const map<TTypeId,string> TYPE_NAMES = {
   TTypeId.CHAR_TYPE: "CHAR"
   TTypeId.INTERVAL_YEAR_MONTH_TYPE: "INTERVAL_YEAR_MONTH"
   TTypeId.INTERVAL_DAY_TIME_TYPE: "INTERVAL_DAY_TIME"
+  TTypeId.TIMESTAMPLOCALTZ_TYPE: "TIMESTAMP WITH LOCAL TIME ZONE"
 }
 
 // Thrift does not support recursively defined types or forward declarations,
@@ -265,7 +277,7 @@ struct TColumnDesc {
 
   // The type descriptor for this column
   2: required TTypeDesc typeDesc
-  
+
   // The ordinal position of this column in the schema
   3: required i32 position
 
@@ -402,6 +414,8 @@ struct TRowSet {
   1: required i64 startRowOffset
   2: required list<TRow> rows
   3: optional list<TColumn> columns
+  4: optional binary binaryColumns
+  5: optional i32 columnCount
 }
 
 // The return status code contained in each response.
@@ -456,6 +470,9 @@ enum TOperationState {
 
   // The operation is in an pending state
   PENDING_STATE,
+
+  // The operation is in an timedout state
+  TIMEDOUT_STATE,
 }
 
 // A string identifier. This is interpreted literally.
@@ -551,7 +568,7 @@ struct TOperationHandle {
 // which operations may be executed.
 struct TOpenSessionReq {
   // The version of the HiveServer2 protocol that the client is using.
-  1: required TProtocolVersion client_protocol = TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V8
+  1: required TProtocolVersion client_protocol = TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V10
 
   // Username and password for authentication.
   // Depending on the authentication scheme being used,
@@ -570,13 +587,22 @@ struct TOpenSessionResp {
   1: required TStatus status
 
   // The protocol version that the server is using.
-  2: required TProtocolVersion serverProtocolVersion = TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V8
+  2: required TProtocolVersion serverProtocolVersion = TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V10
 
   // Session Handle
   3: optional TSessionHandle sessionHandle
 
   // The configuration settings for this session.
   4: optional map<string, string> configuration
+}
+
+struct TSetClientInfoReq {
+  1: required TSessionHandle sessionHandle,
+  2: optional map<string, string> configuration
+}
+
+struct TSetClientInfoResp {
+  1: required TStatus status
 }
 
 
@@ -644,6 +670,7 @@ enum TGetInfoType {
   CLI_CATALOG_NAME =                     10003,
   CLI_COLLATION_SEQ =                    10004,
   CLI_MAX_IDENTIFIER_LEN =               10005,
+  CLI_ODBC_KEYWORDS =                    10006
 }
 
 union TGetInfoValue {
@@ -692,9 +719,12 @@ struct TExecuteStatementReq {
   // is executed. These properties apply to this statement
   // only and will not affect the subsequent state of the Session.
   3: optional map<string, string> confOverlay
-  
+
   // Execute asynchronously when runAsync is true
   4: optional bool runAsync = false
+
+  // The number of seconds after which the query will timeout on the server
+  5: optional i64 queryTimeout = 0
 }
 
 struct TExecuteStatementResp {
@@ -718,13 +748,13 @@ struct TGetTypeInfoReq {
 struct TGetTypeInfoResp {
   1: required TStatus status
   2: optional TOperationHandle operationHandle
-}  
+}
 
 
 // GetCatalogs()
 //
-// Returns the list of catalogs (databases) 
-// Results are ordered by TABLE_CATALOG 
+// Returns the list of catalogs (databases)
+// Results are ordered by TABLE_CATALOG
 //
 // Resultset columns :
 // col1
@@ -834,9 +864,9 @@ struct TGetTablesResp {
 
 // GetTableTypes()
 //
-// Returns the table types available in this database. 
-// The results are ordered by table type. 
-// 
+// Returns the table types available in this database.
+// The results are ordered by table type.
+//
 // col1
 // name: TABLE_TYPE
 // type: STRING
@@ -857,8 +887,8 @@ struct TGetTableTypesResp {
 // Returns a list of columns in the specified tables.
 // The information is returned as a result set which can be fetched
 // using the OperationHandle provided in the response.
-// Results are ordered by TABLE_CAT, TABLE_SCHEM, TABLE_NAME, 
-// and ORDINAL_POSITION. 
+// Results are ordered by TABLE_CAT, TABLE_SCHEM, TABLE_NAME,
+// and ORDINAL_POSITION.
 //
 // Result Set Columns are the same as those for the ODBC CLIColumns
 // function.
@@ -954,7 +984,53 @@ struct TGetFunctionsResp {
   1: required TStatus status
   2: optional TOperationHandle operationHandle
 }
-  
+
+struct TGetPrimaryKeysReq {
+  // Session to run this request against
+  1: required TSessionHandle sessionHandle
+
+  // Name of the catalog.
+  2: optional TIdentifier catalogName
+
+  // Name of the schema.
+  3: optional TIdentifier schemaName
+
+  // Name of the table.
+  4: optional TIdentifier tableName
+}
+
+struct TGetPrimaryKeysResp {
+  1: required TStatus status
+  2: optional TOperationHandle operationHandle
+}
+
+struct TGetCrossReferenceReq {
+  // Session to run this request against
+  1: required TSessionHandle sessionHandle
+
+  // Name of the parent catalog.
+  2: optional TIdentifier parentCatalogName
+
+  // Name of the parent schema.
+  3: optional TIdentifier parentSchemaName
+
+  // Name of the parent table.
+  4: optional TIdentifier parentTableName
+
+  // Name of the foreign catalog.
+  5: optional TIdentifier foreignCatalogName
+
+  // Name of the foreign schema.
+  6: optional TIdentifier foreignSchemaName
+
+  // Name of the foreign table.
+  7: optional TIdentifier foreignTableName
+}
+
+struct TGetCrossReferenceResp {
+  1: required TStatus status
+  2: optional TOperationHandle operationHandle
+}
 
 // GetOperationStatus()
 //
@@ -962,6 +1038,8 @@ struct TGetFunctionsResp {
 struct TGetOperationStatusReq {
   // Session to run this request against
   1: required TOperationHandle operationHandle
+  // optional arguments to get progress information
+  2: optional bool getProgressUpdate
 }
 
 struct TGetOperationStatusResp {
@@ -977,6 +1055,21 @@ struct TGetOperationStatusResp {
 
   // Error message
   5: optional string errorMessage
+
+  // List of statuses of sub tasks
+  6: optional string taskStatus
+
+  // When was the operation started
+  7: optional i64 operationStarted
+
+  // When was the operation completed
+  8: optional i64 operationCompleted
+
+  // If the operation has the result
+  9: optional bool hasResultSet
+
+  10: optional TProgressUpdateResp progressUpdateResponse
+
 }
 
 
@@ -1059,7 +1152,7 @@ struct TFetchResultsReq {
   // The fetch orientation. For V1 this must be either
   // FETCH_NEXT or FETCH_FIRST. Defaults to FETCH_NEXT.
   2: required TFetchOrientation orientation = TFetchOrientation.FETCH_NEXT
-  
+
   // Max number of rows that should be returned in
   // the rowset.
   3: required i64 maxRows
@@ -1132,6 +1225,29 @@ struct TRenewDelegationTokenResp {
   1: required TStatus status
 }
 
+enum TJobExecutionStatus {
+    IN_PROGRESS,
+    COMPLETE,
+    NOT_AVAILABLE
+}
+
+struct TProgressUpdateResp {
+  1: required list<string> headerNames
+  2: required list<list<string>> rows
+  3: required double progressedPercentage
+  4: required TJobExecutionStatus status
+  5: required string footerSummary
+  6: required i64 startTime
+}
+
+struct TGetQueryIdReq {
+  1: required TOperationHandle operationHandle
+}
+
+struct TGetQueryIdResp {
+  1: required string queryId
+}
+
 service TCLIService {
 
   TOpenSessionResp OpenSession(1:TOpenSessionReq req);
@@ -1156,8 +1272,12 @@ service TCLIService {
 
   TGetFunctionsResp GetFunctions(1:TGetFunctionsReq req);
 
+  TGetPrimaryKeysResp GetPrimaryKeys(1:TGetPrimaryKeysReq req);
+
+  TGetCrossReferenceResp GetCrossReference(1:TGetCrossReferenceReq req);
+
   TGetOperationStatusResp GetOperationStatus(1:TGetOperationStatusReq req);
-  
+
   TCancelOperationResp CancelOperation(1:TCancelOperationReq req);
 
   TCloseOperationResp CloseOperation(1:TCloseOperationReq req);
@@ -1171,4 +1291,8 @@ service TCLIService {
   TCancelDelegationTokenResp CancelDelegationToken(1:TCancelDelegationTokenReq req);
 
   TRenewDelegationTokenResp RenewDelegationToken(1:TRenewDelegationTokenReq req);
+
+  TGetQueryIdResp GetQueryId(1:TGetQueryIdReq req);
+
+  TSetClientInfoResp SetClientInfo(1:TSetClientInfoReq req);
 }


### PR DESCRIPTION
Though Hive.jl was built to correspond to [Hive 1.2 protocol specifications](https://github.com/apache/hive/blob/branch-1.2/service/if/TCLIService.thrift) some distributions seem to be using later version of the protocol (even on server version 1.2).

Ref: #13 where HDInsight probably uses the one that comes with HDP.

Since the specification is backward compatible, there seems no harm in updating to the recent version. Hive.jl still connects with `HIVE_CLI_SERVICE_PROTOCOL_V8`.

fixes #13