### PR TITLE
fix bitset conversion

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -42,8 +42,10 @@ const BIT_MASKS = (0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80)
 # the last byte of the bitset is always set to 0x00
 function bitset_to_bools(data::Vector{UInt8}, L::Integer=((length(data)-1)*8))
     bools = Array{Bool}(L)
+    LD = length(data)
     for idx in 1:L
-        bools[idx] = (data[ceil(Int, idx/8)] & BIT_MASKS[rem(idx-1, 8) + 1] > 0x00)
+        didx = ceil(Int, idx/8)
+        bools[idx] = (didx > LD) ? false : (data[didx] & BIT_MASKS[rem(idx-1, 8) + 1] > 0x00)
     end
     bools
 end


### PR DESCRIPTION
This fixes array index out of bounds exception while interpreting bitsets.
Probably hiveserver does not send trailing unnecessary bits.