### PR TITLE
better handling of hive datatypes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ notifications:
   email: false
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - git clone -b 'v0.0.2' --single-branch https://github.com/JuliaCI/PkgEvalHadoopEnv.git ./test/test_setup
+  - git clone -b 'v0.0.4' --single-branch https://github.com/JuliaCI/PkgEvalHadoopEnv.git ./test/test_setup
   - ./test/test_setup/hadoop/setup_hdfs.sh
   - ./test/test_setup/hive/setup_hive.sh
   - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("Hive"); Pkg.test("Hive"; coverage=true)'

--- a/src/util.jl
+++ b/src/util.jl
@@ -34,9 +34,8 @@ end
 
 show(io::IO, sch::TTableSchema) = show(io, dataframe(sch))
 
-function coltypes(sch::TTableSchema)
-    tuple([julia_type(col.typeDesc) for col in sch.columns]...)
-end
+coltypes(sch::TTableSchema) = [julia_type(col.typeDesc) for col in sch.columns]
+colconvfns(sch::TTableSchema) = [julia_conv(col.typeDesc) for col in sch.columns]
 
 const BIT_MASKS = (0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80)
 # the last byte of the bitset is always set to 0x00


### PR DESCRIPTION
Hive returns certain types (that do not have direct mapping in Thrift) in string format.

With this change, Hive.jl will now convert datetime, date and decimal types into native Julia types, instead of keeping them as strings.