### PR TITLE
fix recordset iteration, optimize reading char type

### DIFF
--- a/test/hive_test.jl
+++ b/test/hive_test.jl
@@ -159,7 +159,7 @@ function fetch_records(session)
             println("values: ", cols[2])
             @test typeof(cols[2]) == Vector{Int32}
         end
-        cnt += size(colframe, 1)
+        cnt += length(colframe[1][2])
     end
     close(rs)
     @test cnt <= lim
@@ -188,14 +188,14 @@ function fetch_records(session)
     println(cc)
 
     println("Execute, datatypes:")
-    rs = execute(session, "select * from datatype_test limit 10")
-    cols = columnchunk(rs)
+    rs = execute(session, "select * from datatype_test")
+    cols = columnchunk(rs, 100)
     coltypes = [Bool, Int8, Int16, Int32, Int64, Float32, Float64, String, DateTime, BigFloat, Date, String]
     for ((cn,cv),ct) in zip(cols, coltypes)
         println("name  : ", cn)
         println("values: ", cv)
         @test typeof(cv) == Vector{ct}
-        @test length(cv) <= 10
+        @test length(cv) == 10^4
     end
     close(rs)
 

--- a/test/hive_test.jl
+++ b/test/hive_test.jl
@@ -135,7 +135,8 @@ function fetch_records(session)
     cnt = 0
     for rec in records(rs)
         if rec !== nothing
-            println(rec)
+            (cnt <= 100) && println(rec)
+            (cnt == 100) && println("...")
             cnt += 1
         end
     end
@@ -158,7 +159,7 @@ function fetch_records(session)
     for colframe in columnchunks(rs)
         for cols in colframe
             println("name  : ", cols[1])
-            println("values: ", cols[2])
+            println("values: ", cols[2][1:min(length(cols[2]), 10)])
             @test typeof(cols[2]) == Vector{Int32}
         end
         cnt += length(colframe[1][2])
@@ -187,15 +188,14 @@ function fetch_records(session)
     @test size(cc[1][2], 1) <= lim
     @test typeof(cc[1][2]) == Vector{Int32}
     @test typeof(cc[2][2]) == Vector{Int32}
-    println(cc)
+    println([(n=>(length(v), typeof(v))) for (n,v) in cc])
 
     println("Execute, datatypes:")
     rs = execute(session, "select * from datatype_test")
     cols = columnchunk(rs, 100)
     coltypes = [Bool, Int8, Int16, Int32, Int64, Float32, Float64, String, Union{NAtype,DateTime}, Union{NAtype,BigFloat}, Union{NAtype,Date}, String]
     for ((cn,cv),ct) in zip(cols, coltypes)
-        println("name  : ", cn)
-        println("values: ", cv)
+        println(cn, " => ", cv[1:min(length(cv),10)])
         @test typeof(cv) == Vector{ct}
         @test length(cv) == 10^4
     end

--- a/test/hive_test.jl
+++ b/test/hive_test.jl
@@ -134,8 +134,10 @@ function fetch_records(session)
     rs = execute(session, "select * from twitter_small where fromid <= $maxval limit $lim")
     cnt = 0
     for rec in records(rs)
-        println(rec)
-        cnt += 1
+        if rec !== nothing
+            println(rec)
+            cnt += 1
+        end
     end
     close(rs)
     @test cnt <= lim
@@ -190,7 +192,7 @@ function fetch_records(session)
     println("Execute, datatypes:")
     rs = execute(session, "select * from datatype_test")
     cols = columnchunk(rs, 100)
-    coltypes = [Bool, Int8, Int16, Int32, Int64, Float32, Float64, String, DateTime, BigFloat, Date, String]
+    coltypes = [Bool, Int8, Int16, Int32, Int64, Float32, Float64, String, Union{NAtype,DateTime}, Union{NAtype,BigFloat}, Union{NAtype,Date}, String]
     for ((cn,cv),ct) in zip(cols, coltypes)
         println("name  : ", cn)
         println("values: ", cv)

--- a/test/hive_test.jl
+++ b/test/hive_test.jl
@@ -95,7 +95,8 @@ function create_table_datatype_test(session)
             ("tdatetime", "timestamp"   , ()->replace(string(now() - Dates.Day(rand(UInt8))), "T", " ")),
             ("tbigfloat", "decimal"     , ()->rand(Float64)),
             ("tdate"    , "date"        , ()->Date(now() - Dates.Day(rand(UInt8)))),
-            ("tchar"    , "char(1)"     , ()->('A' + rand(1:20)))
+            ("tchar"    , "char(1)"     , ()->('A' + rand(1:20))),
+            ("tchar2"   , "char(2)"     , ()->randstring(2))
     )
 
     if table_exists
@@ -193,7 +194,7 @@ function fetch_records(session)
     println("Execute, datatypes:")
     rs = execute(session, "select * from datatype_test")
     cols = columnchunk(rs, 100)
-    coltypes = [Bool, Int8, Int16, Int32, Int64, Float32, Float64, String, Union{NAtype,DateTime}, Union{NAtype,BigFloat}, Union{NAtype,Date}, String]
+    coltypes = [Bool, Int8, Int16, Int32, Int64, Float32, Float64, String, Union{DataArrays.NAtype,DateTime}, Union{DataArrays.NAtype,BigFloat}, Union{DataArrays.NAtype,Date}, Char, String]
     for ((cn,cv),ct) in zip(cols, coltypes)
         println(cn, " => ", cv[1:min(length(cv),10)])
         @test typeof(cv) == Vector{ct}


### PR DESCRIPTION
- fix recordset iteration (since `result.hasMoreRows` seems to be false always, added a check on the number of rows retrieved instead)
- using column chunk iterator in row iterator (avoiding dataframe iterator as it is an additional layer over column chunk iterator)
- read `CHAR(1)` columns as `Char` instead of `String`
- make test output less verbose