### PR TITLE
move to Julia 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 os:
   - linux
 julia:
-  - 0.6
+  - 1.0
   - nightly
 matrix:
   fast_finish: true
@@ -12,11 +12,10 @@ matrix:
     - julia: nightly
 notifications:
   email: false
-script:
+before_install:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - git clone -b 'v0.0.5' --single-branch https://github.com/JuliaCI/PkgEvalHadoopEnv.git ./test/test_setup
   - ./test/test_setup/hadoop/setup_hdfs.sh
   - ./test/test_setup/hive/setup_hive.sh
-  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("Hive"); Pkg.test("Hive"; coverage=true)'
 after_success:
   - julia -e 'cd(Pkg.dir("Hive")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder());'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
-julia 0.6
-Compat 0.70.0
-Thrift v0.5.0
+julia 1.0
+Thrift v0.6.0

--- a/src/HS2/HS2.jl
+++ b/src/HS2/HS2.jl
@@ -6,7 +6,6 @@
 
 module HS2
 
-using Compat
 using Thrift
 import Thrift.process, Thrift.meta, Thrift.distribute
 

--- a/src/Hive.jl
+++ b/src/Hive.jl
@@ -1,19 +1,18 @@
 __precompile__(true)
 module Hive
 
-using Compat
 using Thrift
-using Compat.Markdown
-using Compat.Dates
-using Compat.Unicode
+using Markdown
+using Dates
+using Unicode
 
-import Base: close, isready, show, eof, start, next, done, vcat
+import Base: close, isready, show, eof, iterate, vcat
 
 export HiveSession, HiveAuth, HiveAuthSASLPlain, Tabular
 export eof, close, isready, result, cancel, get_info, show
 export catalogs, schemas, tables, tabletypes, functions, columns, execute
 export tabular, tabulars, records, columnchunks, columnchunk
-export start, next, done, iteratorsize
+export iterate, iteratorsize
 
 export InfoType
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -76,13 +76,7 @@ function show_table(io::IO, t; header=nothing, cnames=[n for (n,v) in t], divide
         if style == nothing
             print(io, txt)
         else
-            if isdefined(Compat.Markdown, :with_output_color)
-                Compat.Markdown.with_output_color(style, print, io, txt)
-            elseif isdefined(Compat.Markdown, :with_output_format)
-                Compat.Markdown.with_output_format(style, print, io, txt)
-            else
-                print(io, txt)
-            end
+            Markdown.with_output_color(style, print, io, txt)
         end
         if c == divider
             print(io, "│")

--- a/test/hive_test.jl
+++ b/test/hive_test.jl
@@ -1,13 +1,9 @@
 using Hive
-using Compat
-using Compat.Test
-using Compat.DelimitedFiles
-using Compat.Dates
-using Compat.Random
-
-if VERSION >= v"0.7.0-DEV.4064"
-    using Statistics
-end
+using Test
+using DelimitedFiles
+using Dates
+using Random
+using Statistics
 
 function open_database(f::Function)
     session = HiveSession()


### PR DESCRIPTION
- Move to Julia 1.0
- Use a recent version of Thrift
- Drop Compat, and support for older Julia versions